### PR TITLE
Add client session helper and compatibility alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/mcp_browser_use"]
+packages = ["src/mcp_browser_use", "src/mcp_browser"]
 
 [project.scripts]
 mcp-browser-use = "mcp_browser_use.server:main"

--- a/src/mcp_browser/__init__.py
+++ b/src/mcp_browser/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility namespace for the historic ``mcp_browser.use`` package."""
+
+from __future__ import annotations
+
+from mcp_browser_use import (
+    AgentNotRegisteredError,
+    app,
+    create_client_session,
+    main,
+)
+
+__all__ = ["AgentNotRegisteredError", "app", "create_client_session", "main"]

--- a/src/mcp_browser/use/__init__.py
+++ b/src/mcp_browser/use/__init__.py
@@ -1,0 +1,7 @@
+"""Backwards compatible accessors for the ``mcp_browser.use`` namespace."""
+
+from __future__ import annotations
+
+from .mcp_browser_use import AgentNotRegisteredError, create_client_session
+
+__all__ = ["AgentNotRegisteredError", "create_client_session"]

--- a/src/mcp_browser/use/mcp_browser_use.py
+++ b/src/mcp_browser/use/mcp_browser_use.py
@@ -1,0 +1,10 @@
+"""Compatibility shim forwarding to :mod:`mcp_browser_use`."""
+
+from __future__ import annotations
+
+from mcp_browser_use.mcp_browser_use import (  # noqa: F401
+    AgentNotRegisteredError,
+    create_client_session,
+)
+
+__all__ = ["AgentNotRegisteredError", "create_client_session"]

--- a/src/mcp_browser_use/__init__.py
+++ b/src/mcp_browser_use/__init__.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
-"""MCP server for browser-use"""
+"""MCP server for browser-use."""
 
+from mcp_browser_use.mcp_browser_use import (  # noqa: F401
+    AgentNotRegisteredError,
+    create_client_session,
+)
 from mcp_browser_use.server import app, main
 
-
-__all__ = ["app", "main"]
+__all__ = ["app", "main", "create_client_session", "AgentNotRegisteredError"]

--- a/src/mcp_browser_use/agent/custom_agent.py
+++ b/src/mcp_browser_use/agent/custom_agent.py
@@ -524,6 +524,7 @@ class CustomAgent(Agent):
                     title_font=title_font,
                     margin=margin,
                     logo=logo,
+                    line_spacing=line_spacing,
                 )
 
             images.append(image)
@@ -595,6 +596,46 @@ class CustomAgent(Agent):
 
         img.alpha_composite(overlay)
         return img.convert("RGB")
+
+    def _wrap_text_to_lines(
+        self,
+        draw: ImageDraw.ImageDraw,
+        text: str,
+        font: ImageFont.FreeTypeFont,
+        max_width: int,
+    ) -> list[str]:
+        """Split ``text`` into lines that fit within ``max_width`` pixels."""
+
+        if not text:
+            return []
+
+        if max_width <= 0:
+            return [text]
+
+        wrapped_lines: list[str] = []
+
+        lines = text.splitlines()
+        if not lines:
+            lines = [text]
+
+        for raw_line in lines:
+            words = raw_line.split()
+            if not words:
+                wrapped_lines.append("")
+                continue
+
+            current_line = words[0]
+            for word in words[1:]:
+                candidate = f"{current_line} {word}" if current_line else word
+                if draw.textlength(candidate, font=font) <= max_width:
+                    current_line = candidate
+                else:
+                    wrapped_lines.append(current_line)
+                    current_line = word
+
+            wrapped_lines.append(current_line)
+
+        return wrapped_lines
 
     def _add_overlay_to_image(
         self,

--- a/src/mcp_browser_use/client.py
+++ b/src/mcp_browser_use/client.py
@@ -57,9 +57,12 @@ async def create_client_session(
             "'client_kwargs' cannot be combined with 'client_factory'."
         )
 
-    session_client = client
-    if session_client is None:
-        session_client = client_factory() if client_factory else Client(app, **client_kwargs)
+    if client is not None:
+        session_client = client
+    elif client_factory is not None:
+        session_client = client_factory()
+    else:
+        session_client = Client(app, **client_kwargs)
 
     async with session_client as connected_client:
         yield connected_client

--- a/src/mcp_browser_use/client.py
+++ b/src/mcp_browser_use/client.py
@@ -1,0 +1,65 @@
+"""Client helpers for interacting with the in-process FastMCP server."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Callable, Optional
+
+from fastmcp.client import Client
+
+from .server import app
+
+
+class AgentNotRegisteredError(RuntimeError):
+    """Error raised when attempting to control an agent that is not running."""
+
+
+@asynccontextmanager
+async def create_client_session(
+    client: Optional[Client] = None,
+    *,
+    client_factory: Optional[Callable[[], Client]] = None,
+    **client_kwargs: Any,
+) -> AsyncIterator[Client]:
+    """Create an asynchronous context manager for interacting with the server.
+
+    Parameters
+    ----------
+    client:
+        An existing :class:`fastmcp.client.Client` instance. If provided, the
+        caller is responsible for its configuration. ``client_kwargs`` must not
+        be supplied in this case.
+    client_factory:
+        Optional callable used to lazily construct a client. This is useful in
+        testing where a lightweight stub client might be injected. If provided,
+        the callable is invoked with no arguments and ``client_kwargs`` must not
+        be supplied.
+    **client_kwargs:
+        Additional keyword arguments forwarded to :class:`fastmcp.client.Client`
+        when neither ``client`` nor ``client_factory`` is provided.
+
+    Yields
+    ------
+    Client
+        A connected FastMCP client ready for use within the context manager.
+    """
+
+    if client is not None and client_factory is not None:
+        raise ValueError("Provide either 'client' or 'client_factory', not both.")
+
+    if client is not None and client_kwargs:
+        raise ValueError(
+            "'client_kwargs' cannot be used when an explicit client instance is provided."
+        )
+
+    if client_factory is not None and client_kwargs:
+        raise ValueError(
+            "'client_kwargs' cannot be combined with 'client_factory'."
+        )
+
+    session_client = client
+    if session_client is None:
+        session_client = client_factory() if client_factory else Client(app, **client_kwargs)
+
+    async with session_client as connected_client:
+        yield connected_client

--- a/src/mcp_browser_use/mcp_browser_use.py
+++ b/src/mcp_browser_use/mcp_browser_use.py
@@ -1,0 +1,7 @@
+"""Public entry-points for backwards compatible imports."""
+
+from __future__ import annotations
+
+from .client import AgentNotRegisteredError, create_client_session
+
+__all__ = ["AgentNotRegisteredError", "create_client_session"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Test fixtures and environment setup for the test suite."""
+
+import importlib
+import os
+import sys
+import types
+
+BASE_DIR = os.path.dirname(__file__)
+STUBS_DIR = os.path.join(BASE_DIR, "stubs")
+SRC_DIR = os.path.join(os.path.dirname(BASE_DIR), "src")
+
+for path in (STUBS_DIR, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+if "langchain_openai" not in sys.modules:
+    importlib.import_module("langchain_openai")
+
+if "langchain_anthropic" not in sys.modules:
+    module = types.ModuleType("langchain_anthropic")
+
+    class ChatAnthropic:  # type: ignore[too-many-ancestors]
+        def __init__(self, *args, **kwargs):
+            pass
+
+    module.ChatAnthropic = ChatAnthropic
+    sys.modules["langchain_anthropic"] = module
+
+if "langchain_google_genai" not in sys.modules:
+    module = types.ModuleType("langchain_google_genai")
+
+    class ChatGoogleGenerativeAI:  # type: ignore[too-many-ancestors]
+        def __init__(self, *args, **kwargs):
+            pass
+
+    module.ChatGoogleGenerativeAI = ChatGoogleGenerativeAI
+    sys.modules["langchain_google_genai"] = module
+
+if "langchain_ollama" not in sys.modules:
+    module = types.ModuleType("langchain_ollama")
+
+    class ChatOllama:  # type: ignore[too-many-ancestors]
+        def __init__(self, *args, **kwargs):
+            pass
+
+    module.ChatOllama = ChatOllama
+    sys.modules["langchain_ollama"] = module
+
+if "playwright" not in sys.modules:
+    playwright_module = types.ModuleType("playwright")
+    async_api_module = types.ModuleType("playwright.async_api")
+
+    class Browser:
+        async def close(self):
+            pass
+
+    class BrowserContext:
+        async def close(self):
+            pass
+
+    class Playwright:
+        class Chromium:
+            async def connect(self, *args, **kwargs):
+                return Browser()
+
+            async def connect_over_cdp(self, *args, **kwargs):
+                return Browser()
+
+            async def launch(self, *args, **kwargs):
+                return Browser()
+
+        def __init__(self):
+            self.chromium = Playwright.Chromium()
+
+    async def async_playwright():
+        class Manager:
+            async def __aenter__(self):
+                return Playwright()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        return Manager()
+
+    async_api_module.Browser = Browser
+    async_api_module.BrowserContext = BrowserContext
+    async_api_module.Playwright = Playwright
+    async_api_module.async_playwright = async_playwright
+
+    playwright_module.async_api = async_api_module
+    sys.modules["playwright"] = playwright_module
+    sys.modules["playwright.async_api"] = async_api_module

--- a/tests/stubs/PIL/__init__.py
+++ b/tests/stubs/PIL/__init__.py
@@ -54,6 +54,8 @@ class ImageDraw:
         def textlength(self, text, font=None):
             return len(text) * 10
 
+    ImageDraw = Draw
+
 class ImageFont:
     class FreeTypeFont:
         pass

--- a/tests/stubs/browser_use/__init__.py
+++ b/tests/stubs/browser_use/__init__.py
@@ -1,0 +1,9 @@
+class BrowserConfig:
+    """Minimal stub mirroring the configuration dataclass used in production."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+__all__ = ["BrowserConfig"]

--- a/tests/stubs/browser_use/browser/context.py
+++ b/tests/stubs/browser_use/browser/context.py
@@ -1,5 +1,12 @@
+class BrowserContextConfig:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
 class BrowserContext:
     async def get_state(self, *args, **kwargs):
         pass
+
     async def close(self):
         pass

--- a/tests/stubs/langchain_openai/__init__.py
+++ b/tests/stubs/langchain_openai/__init__.py
@@ -1,1 +1,3 @@
-from .chat_models import ChatOpenAI
+from .chat_models import AzureChatOpenAI, ChatOpenAI
+
+__all__ = ["ChatOpenAI", "AzureChatOpenAI"]

--- a/tests/stubs/langchain_openai/chat_models/__init__.py
+++ b/tests/stubs/langchain_openai/chat_models/__init__.py
@@ -2,9 +2,20 @@ class Base:
     pass
 
 class ChatOpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
     root_async_client = None
     model_name = 'mock'
     def with_structured_output(self, *args, **kwargs):
         return self
     async def ainvoke(self, *args, **kwargs):
         return {}
+
+
+class AzureChatOpenAI(ChatOpenAI):
+    """Minimal stub mirroring the OpenAI chat client API."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1,0 +1,89 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+from mcp_browser_use.client import AgentNotRegisteredError, create_client_session
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_client_session_uses_supplied_client():
+    events = []
+
+    class DummyClient:
+        def __init__(self):
+            self.connected = False
+
+        async def __aenter__(self):
+            events.append("enter")
+            self.connected = True
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            events.append("exit")
+            self.connected = False
+
+    dummy = DummyClient()
+    async with create_client_session(client=dummy) as session:
+        assert session is dummy
+        assert dummy.connected
+
+    assert events == ["enter", "exit"]
+    assert dummy.connected is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_client_session_accepts_factory():
+    events = []
+
+    class DummyClient:
+        async def __aenter__(self):
+            events.append("enter")
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            events.append("exit")
+
+    async with create_client_session(client_factory=DummyClient) as session:
+        assert isinstance(session, DummyClient)
+
+    assert events == ["enter", "exit"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_client_session_rejects_mixed_arguments():
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    dummy = DummyClient()
+
+    with pytest.raises(ValueError):
+        async with create_client_session(client=dummy, timeout=5):
+            pass
+
+    with pytest.raises(ValueError):
+        async with create_client_session(client_factory=DummyClient, timeout=5):
+            pass
+
+    with pytest.raises(ValueError):
+        async with create_client_session(client=dummy, client_factory=DummyClient):
+            pass
+
+
+def test_legacy_namespace_imports():
+    module = importlib.import_module("mcp_browser.use.mcp_browser_use")
+
+    assert module.create_client_session is create_client_session
+    assert module.AgentNotRegisteredError is AgentNotRegisteredError
+
+
+def test_exception_type():
+    assert issubclass(AgentNotRegisteredError, RuntimeError)

--- a/tests/test_gif_creation.py
+++ b/tests/test_gif_creation.py
@@ -8,13 +8,6 @@ BASE_DIR = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(BASE_DIR, 'stubs'))
 sys.path.insert(0, os.path.join(os.path.dirname(BASE_DIR), 'src'))
 
-# Create a minimal mcp_browser_use package without triggering server imports
-import types, pathlib
-pkg_root = pathlib.Path(os.path.dirname(BASE_DIR)) / 'src' / 'mcp_browser_use'
-mcp_pkg = types.ModuleType('mcp_browser_use')
-mcp_pkg.__path__ = [str(pkg_root)]
-sys.modules.setdefault('mcp_browser_use', mcp_pkg)
-
 from PIL import Image
 
 from mcp_browser_use.agent.custom_agent import CustomAgent


### PR DESCRIPTION
## Summary
- add a client helper module that exposes `create_client_session` and `AgentNotRegisteredError`
- provide backwards-compatible namespaces for `mcp_browser.use` and update packaging to include them
- improve GIF generation text wrapping and expand test scaffolding/stubs for dependency compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99e9e69bc832498c03709fd09615b