### PR TITLE
Ensure CustomAgent uses unique controllers

### DIFF
--- a/src/mcp_browser_use/agent/custom_agent.py
+++ b/src/mcp_browser_use/agent/custom_agent.py
@@ -51,7 +51,7 @@ class CustomAgent(Agent):
         add_infos: str = "",
         browser: Optional[Browser] = None,
         browser_context: Optional[BrowserContext] = None,
-        controller: Controller = Controller(),
+        controller: Optional[Controller] = None,
         use_vision: bool = True,
         save_conversation_path: Optional[str] = None,
         max_failures: int = 5,
@@ -82,7 +82,8 @@ class CustomAgent(Agent):
         :param add_infos: Additional information or context to pass to the agent.
         :param browser: Optional Browser instance.
         :param browser_context: Optional BrowserContext to share state.
-        :param controller: Controller for handling multi-step actions.
+        :param controller: Optional controller for handling multi-step actions. A new
+            controller is created when not provided.
         :param use_vision: Whether to use vision-based element detection.
         :param save_conversation_path: File path to store conversation logs.
         :param max_failures: Max consecutive failures allowed before aborting.
@@ -96,6 +97,9 @@ class CustomAgent(Agent):
         :param tool_call_in_content: Whether tool calls are in the raw model content.
         :param agent_state: Shared state to detect external stop signals, store last valid state, etc.
         """
+        controller = controller or Controller()
+        self.controller = controller
+
         super().__init__(
             task=task,
             llm=llm,

--- a/tests/test_custom_agent_controller.py
+++ b/tests/test_custom_agent_controller.py
@@ -60,7 +60,7 @@ def test_custom_agent_creates_independent_default_controllers(custom_agent, monk
 
     monkeypatch.setattr(custom_agent, "Controller", TrackingController)
 
-    llm = BaseChatModel()
+    llm = Mock(spec=BaseChatModel)
     agent_one = custom_agent.CustomAgent(task="Task one", llm=llm)
     agent_two = custom_agent.CustomAgent(task="Task two", llm=llm)
 

--- a/tests/test_custom_agent_controller.py
+++ b/tests/test_custom_agent_controller.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+BASE_DIR = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(BASE_DIR, "stubs"))
+sys.path.insert(0, os.path.join(os.path.dirname(BASE_DIR), "src"))
+
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+
+import mcp_browser_use.agent.custom_agent as custom_agent_module
+
+
+@pytest.fixture
+def custom_agent(monkeypatch):
+    class DummyMessageManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        custom_agent_module,
+        "CustomMassageManager",
+        DummyMessageManager,
+    )
+
+    def fake_agent_init(self, *args, **kwargs):
+        self.task = kwargs.get("task")
+        self.llm = kwargs.get("llm")
+        self.browser = kwargs.get("browser")
+        self.browser_context = kwargs.get("browser_context")
+        self.system_prompt_class = kwargs.get("system_prompt_class")
+        self.max_input_tokens = kwargs.get("max_input_tokens")
+        self.include_attributes = kwargs.get("include_attributes")
+        self.max_error_length = kwargs.get("max_error_length")
+        self.max_actions_per_step = kwargs.get("max_actions_per_step")
+        self.tool_call_in_content = kwargs.get("tool_call_in_content")
+        self.use_vision = kwargs.get("use_vision")
+        self.save_conversation_path = kwargs.get("save_conversation_path")
+        self.max_failures = kwargs.get("max_failures")
+        self.retry_delay = kwargs.get("retry_delay")
+        self.validate_output = kwargs.get("validate_output")
+        self.n_steps = 0
+        self._last_result = None
+        self.message_manager = None
+        self.history = None
+        self.generate_gif = False
+
+    monkeypatch.setattr(custom_agent_module.Agent, "__init__", fake_agent_init)
+
+    return custom_agent_module
+
+
+def test_custom_agent_creates_independent_default_controllers(custom_agent, monkeypatch):
+    controllers = []
+
+    class TrackingController(custom_agent.Controller):
+        def __init__(self):
+            super().__init__()
+            controllers.append(self)
+
+    monkeypatch.setattr(custom_agent, "Controller", TrackingController)
+
+    llm = BaseChatModel()
+    agent_one = custom_agent.CustomAgent(task="Task one", llm=llm)
+    agent_two = custom_agent.CustomAgent(task="Task two", llm=llm)
+
+    assert agent_one.controller is not agent_two.controller
+    assert controllers == [agent_one.controller, agent_two.controller]
+
+
+def test_custom_agent_uses_supplied_controller(custom_agent):
+    llm = BaseChatModel()
+    provided_controller = custom_agent.Controller()
+
+    agent = custom_agent.CustomAgent(
+        task="Task with supplied controller",
+        llm=llm,
+        controller=provided_controller,
+    )
+
+    assert agent.controller is provided_controller

--- a/tests/test_custom_agent_controller.py
+++ b/tests/test_custom_agent_controller.py
@@ -69,7 +69,7 @@ def test_custom_agent_creates_independent_default_controllers(custom_agent, monk
 
 
 def test_custom_agent_uses_supplied_controller(custom_agent):
-    llm = BaseChatModel()
+    llm = Mock(spec=BaseChatModel)
     provided_controller = custom_agent.Controller()
 
     agent = custom_agent.CustomAgent(

--- a/tests/test_custom_agent_controller.py
+++ b/tests/test_custom_agent_controller.py
@@ -24,21 +24,9 @@ def custom_agent(monkeypatch):
     )
 
     def fake_agent_init(self, *args, **kwargs):
-        self.task = kwargs.get("task")
-        self.llm = kwargs.get("llm")
-        self.browser = kwargs.get("browser")
-        self.browser_context = kwargs.get("browser_context")
-        self.system_prompt_class = kwargs.get("system_prompt_class")
-        self.max_input_tokens = kwargs.get("max_input_tokens")
-        self.include_attributes = kwargs.get("include_attributes")
-        self.max_error_length = kwargs.get("max_error_length")
-        self.max_actions_per_step = kwargs.get("max_actions_per_step")
-        self.tool_call_in_content = kwargs.get("tool_call_in_content")
-        self.use_vision = kwargs.get("use_vision")
-        self.save_conversation_path = kwargs.get("save_conversation_path")
-        self.max_failures = kwargs.get("max_failures")
-        self.retry_delay = kwargs.get("retry_delay")
-        self.validate_output = kwargs.get("validate_output")
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        # Set attributes not passed in kwargs that are needed
         self.n_steps = 0
         self._last_result = None
         self.message_manager = None


### PR DESCRIPTION
## Summary
- update `CustomAgent` to treat the controller parameter as optional and instantiate a fresh default per instance
- assign the controller to the agent before initialization uses it for message manager setup
- add unit tests covering unique default controllers and honoring supplied controllers

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9bba6237c8324b95b1d8a826dc87f