### PR TITLE
Rename agent execution functions for clarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ build-backend = "hatchling.build"
 packages = ["src/mcp_browser_use", "src/mcp_browser"]
 
 [project.scripts]
-mcp-browser-use = "mcp_browser_use.server:main"
+mcp-browser-use = "mcp_browser_use.server:launch_mcp_browser_use_server"

--- a/src/mcp_browser/__init__.py
+++ b/src/mcp_browser/__init__.py
@@ -6,7 +6,12 @@ from mcp_browser_use import (
     AgentNotRegisteredError,
     app,
     create_client_session,
-    main,
+    launch_mcp_browser_use_server,
 )
 
-__all__ = ["AgentNotRegisteredError", "app", "create_client_session", "main"]
+__all__ = [
+    "AgentNotRegisteredError",
+    "app",
+    "create_client_session",
+    "launch_mcp_browser_use_server",
+]

--- a/src/mcp_browser_use/__init__.py
+++ b/src/mcp_browser_use/__init__.py
@@ -6,6 +6,11 @@ from mcp_browser_use.mcp_browser_use import (  # noqa: F401
     AgentNotRegisteredError,
     create_client_session,
 )
-from mcp_browser_use.server import app, main
+from mcp_browser_use.server import app, launch_mcp_browser_use_server
 
-__all__ = ["app", "main", "create_client_session", "AgentNotRegisteredError"]
+__all__ = [
+    "app",
+    "launch_mcp_browser_use_server",
+    "create_client_session",
+    "AgentNotRegisteredError",
+]

--- a/src/mcp_browser_use/agent/custom_agent.py
+++ b/src/mcp_browser_use/agent/custom_agent.py
@@ -402,10 +402,12 @@ class CustomAgent(Agent):
             logger.debug(f"Full traceback: {traceback.format_exc()}")
             return False
 
-    @time_execution_async("--step")
-    async def step(self, step_info: Optional[CustomAgentStepInfo] = None) -> None:
+    @time_execution_async("--execute-agent-step")
+    async def execute_agent_step(
+        self, step_info: Optional[CustomAgentStepInfo] = None
+    ) -> None:
         """
-        Execute one step of the task:
+        Execute a single agent step of the task:
         1) Capture browser state
         2) Query LLM for next action
         3) Execute that action(s)
@@ -743,10 +745,10 @@ class CustomAgent(Agent):
         image.alpha_composite(overlay)
         return image.convert("RGB")
 
-    async def run(self, max_steps: int = 100) -> AgentHistoryList:
+    async def execute_agent_task(self, max_steps: int = 100) -> AgentHistoryList:
         """
-        Execute the entire task for up to max_steps or until 'done'.
-        Checks for external stop signals, logs each step in self.history.
+        Execute the entire agent task for up to max_steps or until 'done'.
+        Checks for external stop signals and logs each step in self.history.
         """
         try:
             logger.info(f"🚀 Starting task: {self.task}")
@@ -784,8 +786,8 @@ class CustomAgent(Agent):
                 if self._too_many_failures():
                     break
 
-                # 4) Execute one step
-                await self.step(step_info)
+                # 4) Execute one detailed agent step
+                await self.execute_agent_step(step_info)
 
                 if self.history.is_done():
                     if self.validate_output and step < max_steps - 1:

--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -192,8 +192,8 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
             agent_state=_global_agent_state,
         )
 
-        # Run agent
-        history = await _global_agent.run(max_steps=max_steps)
+        # Execute the agent task lifecycle
+        history = await _global_agent.execute_agent_task(max_steps=max_steps)
 
         # Extract final result from the agent's history
         final_result = history.final_result()
@@ -211,7 +211,7 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
         await _cleanup_browser_resources()
 
 
-def main() -> None:
+def launch_mcp_browser_use_server() -> None:
     """
     Entry point for running the FastMCP application.
     Handles server start and final resource cleanup.
@@ -232,4 +232,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    launch_mcp_browser_use_server()

--- a/src/mcp_browser_use/utils/utils.py
+++ b/src/mcp_browser_use/utils/utils.py
@@ -190,11 +190,7 @@ async def capture_screenshot(browser_context) -> Optional[str]:
         logger.debug("No pages available in playwright_context.")
         return None
 
-    active_page = browser_pages[0]
-    for candidate_page in browser_pages:
-        if candidate_page.url != "about:blank":
-            active_page = candidate_page
-            break
+    active_page = next((page for page in browser_pages if page.url != "about:blank"), browser_pages[0])
 
     try:
         screenshot = await active_page.screenshot(type="jpeg", quality=75, scale="css")

--- a/src/mcp_browser_use/utils/utils.py
+++ b/src/mcp_browser_use/utils/utils.py
@@ -114,14 +114,14 @@ def encode_image(img_path: Optional[str]) -> Optional[str]:
         return None
 
     try:
-        with open(img_path, "rb") as fin:
-            image_data = base64.b64encode(fin.read()).decode("utf-8")
+        with open(img_path, "rb") as image_file:
+            image_data = base64.b64encode(image_file.read()).decode("utf-8")
         return image_data
-    except FileNotFoundError as e:
-        logger.error(f"Image not found at path {img_path}: {e}")
+    except FileNotFoundError as error:
+        logger.error(f"Image not found at path {img_path}: {error}")
         raise
-    except Exception as e:
-        logger.error(f"Error encoding image at {img_path}: {e}")
+    except Exception as error:
+        logger.error(f"Error encoding image at {img_path}: {error}")
         raise
 
 
@@ -145,19 +145,21 @@ def get_latest_files(
 
     for file_type in file_types:
         try:
-            matches = list(Path(directory).rglob(f"*{file_type}"))
-            if matches:
+            matching_files = list(Path(directory).rglob(f"*{file_type}"))
+            if matching_files:
                 # Sort or use max() by modified time
-                latest = max(matches, key=lambda p: p.stat().st_mtime)
+                most_recent_file = max(matching_files, key=lambda path: path.stat().st_mtime)
                 # Check if file is not actively being written
-                if time.time() - latest.stat().st_mtime > 1.0:
-                    latest_files[file_type] = str(latest)
+                if time.time() - most_recent_file.stat().st_mtime > 1.0:
+                    latest_files[file_type] = str(most_recent_file)
                 else:
                     logger.debug(
-                        f"Skipping file {latest} - possibly still being written."
+                        f"Skipping file {most_recent_file} - possibly still being written."
                     )
-        except Exception as e:
-            logger.error(f"Error getting latest {file_type} file in '{directory}': {e}")
+        except Exception as error:
+            logger.error(
+                f"Error getting latest {file_type} file in '{directory}': {error}"
+            )
 
     return latest_files
 
@@ -183,21 +185,21 @@ async def capture_screenshot(browser_context) -> Optional[str]:
         return None
 
     # Find the first non-blank page
-    pages = playwright_context.pages
-    if not pages:
+    browser_pages = playwright_context.pages
+    if not browser_pages:
         logger.debug("No pages available in playwright_context.")
         return None
 
-    active_page = pages[0]
-    for page in pages:
-        if page.url != "about:blank":
-            active_page = page
+    active_page = browser_pages[0]
+    for candidate_page in browser_pages:
+        if candidate_page.url != "about:blank":
+            active_page = candidate_page
             break
 
     try:
         screenshot = await active_page.screenshot(type="jpeg", quality=75, scale="css")
-        encoded = base64.b64encode(screenshot).decode("utf-8")
-        return encoded
-    except Exception as e:
-        logger.error(f"Failed to capture screenshot: {e}")
+        encoded_screenshot = base64.b64encode(screenshot).decode("utf-8")
+        return encoded_screenshot
+    except Exception as error:
+        logger.error(f"Failed to capture screenshot: {error}")
         return None


### PR DESCRIPTION
## Summary
- rename the agent step and task lifecycle methods to descriptive names and adjust internal calls
- expose a descriptive server entry point name throughout the package and script configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d668b1fb7c8324a21d3e953487fd3e