### PR TITLE
Refactor LLM provider factory mapping

### DIFF
--- a/src/mcp_browser_use/utils/utils.py
+++ b/src/mcp_browser_use/utils/utils.py
@@ -70,7 +70,7 @@ def _azure_openai_params(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-LLM_PROVIDERS: Dict[str, Tuple[Any, Callable[[Dict[str, Any]], Dict[str, Any]]]] = {
+LLM_PROVIDERS: Dict[str, Tuple[Type, Callable[[Dict[str, Any]], Dict[str, Any]]]] = {
     "anthropic": (ChatAnthropic, _anthropic_params),
     "openai": (ChatOpenAI, _openai_params),
     "deepseek": (ChatOpenAI, _deepseek_params),


### PR DESCRIPTION
## Summary
- refactor `get_llm_model` to use a provider-to-class mapping with dedicated parameter builders
- centralize default parameter handling for each LLM provider to simplify future extensions

## Testing
- `pytest tests/test_utils.py -k get_llm_model`


------
https://chatgpt.com/codex/tasks/task_e_68d6c02fff64832494585c2bb4e559af