### PR TITLE
Ensure browser session lifecycle is explicit

### DIFF
--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -76,8 +76,7 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
 
         # Create a fresh browser session for this run
         browser_session = create_browser_session()
-        if hasattr(browser_session, "start"):
-            await browser_session.start()
+        await browser_session.start()
 
         # Create controller and agent
         controller = CustomController()

--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -7,7 +7,7 @@ import traceback
 import logging
 from typing import Any, Optional
 
-from browser_use import BrowserSession
+from browser_use import Browser
 from fastmcp import FastMCP
 from mcp_browser_use.agent.custom_agent import CustomAgent
 from mcp_browser_use.controller.custom_controller import CustomController
@@ -32,7 +32,7 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
     :return: The final result string from the agent run.
     """
 
-    browser_session: Optional[BrowserSession] = None
+    browser_session: Optional[Browser] = None
     agent_state = AgentState()
 
     try:
@@ -76,6 +76,8 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
 
         # Create a fresh browser session for this run
         browser_session = create_browser_session()
+        if hasattr(browser_session, "start"):
+            await browser_session.start()
 
         # Create controller and agent
         controller = CustomController()
@@ -114,9 +116,14 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
 
         if browser_session:
             try:
-                await browser_session.kill()
+                await browser_session.stop()
             except Exception as browser_error:
-                logger.warning("Error closing browser session: %s", browser_error)
+                logger.warning(
+                    "Failed to stop browser session gracefully, killing it: %s",
+                    browser_error,
+                )
+                if hasattr(browser_session, "kill"):
+                    await browser_session.kill()
 
 
 def launch_mcp_browser_use_server() -> None:


### PR DESCRIPTION
## Summary
- switch to the Browser alias and initialize sessions with start() before agent use
- stop browser sessions gracefully and fall back to kill() only if stop() fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d709c29cb4832482e40abc1a66f53b