### PR TITLE
Handle missing use_vision argument when fetching browser state

### DIFF
--- a/src/mcp_browser_use/agent/custom_agent.py
+++ b/src/mcp_browser_use/agent/custom_agent.py
@@ -442,7 +442,13 @@ class CustomAgent(Agent):
         result: List[ActionResult] = []
 
         try:
-            state = await self.browser_context.get_state(use_vision=self.use_vision)
+            try:
+                state = await self.browser_context.get_state(use_vision=self.use_vision)
+            except TypeError:
+                logger.warning(
+                    "get_state does not support 'use_vision' argument, falling back."
+                )
+                state = await self.browser_context.get_state()
             self.message_manager.add_state_message(state, self._last_result, step_info)
             input_messages = self.message_manager.get_messages()
 


### PR DESCRIPTION
## Summary
- wrap browser context get_state call in a TypeError fallback to support signatures without the use_vision argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70b7d4c208324b90cf4e56c73d6c8