### PR TITLE
Refactor logging configuration into shared helper

### DIFF
--- a/src/mcp_browser_use/agent/custom_agent.py
+++ b/src/mcp_browser_use/agent/custom_agent.py
@@ -33,12 +33,6 @@ from mcp_browser_use.utils.agent_state import AgentState
 from mcp_browser_use.agent.custom_massage_manager import CustomMassageManager
 from mcp_browser_use.agent.custom_views import CustomAgentOutput, CustomAgentStepInfo
 
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/mcp_browser_use/agent/custom_massage_manager.py
+++ b/src/mcp_browser_use/agent/custom_massage_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import logging
-import os
 from typing import List, Optional, Type
 
 from browser_use.agent.message_manager.service import MessageManager
@@ -16,12 +15,6 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, AIMessage
 
 from mcp_browser_use.agent.custom_prompts import CustomAgentMessagePrompt
-
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_browser_use/browser/browser_manager.py
+++ b/src/mcp_browser_use/browser/browser_manager.py
@@ -18,12 +18,6 @@ from typing import Any, Dict, Optional
 from browser_use import BrowserSession
 from browser_use.browser.profile import ProxySettings
 
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
-
 logger = logging.getLogger(__name__)
 
 _BOOL_TRUE = {"1", "true", "yes", "on"}

--- a/src/mcp_browser_use/controller/custom_controller.py
+++ b/src/mcp_browser_use/controller/custom_controller.py
@@ -1,19 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import os
 import sys
 
 import pyperclip
 from browser_use import BrowserSession
 from browser_use.agent.views import ActionResult
 from browser_use.controller.service import Controller
-
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import asyncio
 import os
+
+from mcp_browser_use.utils.logging import configure_logging
+
+configure_logging()
+
+import asyncio
 import sys
 import traceback
 import logging
@@ -15,11 +20,6 @@ from mcp_browser_use.browser.browser_manager import create_browser_session
 from mcp_browser_use.utils import utils
 from mcp_browser_use.utils.agent_state import AgentState
 
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 app = FastMCP("mcp_browser_use")

--- a/src/mcp_browser_use/utils/logging.py
+++ b/src/mcp_browser_use/utils/logging.py
@@ -1,0 +1,37 @@
+"""Centralised logging configuration utilities for the MCP browser agent."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+
+_DEFAULT_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+
+
+def _resolve_level(level_name: Optional[str]) -> int:
+    """Translate a string level name into a numeric logging level."""
+
+    if not level_name:
+        return logging.INFO
+
+    if level_name.isdigit():
+        return int(level_name)
+
+    resolved = logging.getLevelName(level_name.upper())
+    if isinstance(resolved, str):  # logging returns the input if unknown
+        return logging.INFO
+    return resolved  # type: ignore[return-value]
+
+
+def configure_logging() -> None:
+    """Configure the root logger once for the application."""
+
+    level = _resolve_level(os.getenv("LOG_LEVEL"))
+
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format=_DEFAULT_FORMAT)
+    else:
+        root_logger.setLevel(level)

--- a/src/mcp_browser_use/utils/utils.py
+++ b/src/mcp_browser_use/utils/utils.py
@@ -13,12 +13,6 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
-# Logging
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_logging_configuration.py
+++ b/tests/test_logging_configuration.py
@@ -1,0 +1,38 @@
+"""Smoke tests around module imports and logging configuration."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from typing import Iterable
+
+import pytest
+
+
+MODULES_TO_TEST: Iterable[str] = (
+    "mcp_browser_use.controller.custom_controller",
+    "mcp_browser_use.utils.utils",
+    "mcp_browser_use.agent.custom_agent",
+    "mcp_browser_use.agent.custom_massage_manager",
+)
+
+
+@pytest.mark.parametrize("module_name", MODULES_TO_TEST)
+def test_module_import_does_not_call_basic_config(module_name: str, monkeypatch) -> None:
+    """Ensure importing project modules does not invoke ``logging.basicConfig``."""
+
+    # Import once so that shared third-party dependencies are cached.
+    importlib.import_module(module_name)
+    sys.modules.pop(module_name, None)
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def record_basic_config(*args: object, **kwargs: object) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(logging, "basicConfig", record_basic_config)
+
+    importlib.import_module(module_name)
+
+    assert calls == [], f"Module {module_name} should not call logging.basicConfig during import"


### PR DESCRIPTION
## Summary
- centralize logging configuration in a new helper and invoke it from the MCP server entrypoint
- remove module-level `logging.basicConfig` calls in favor of per-logger configuration
- add a smoke test to ensure importing key modules does not trigger `logging.basicConfig`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d717ae95f08324ad9624f0afd88a59