### PR TITLE
Derive CDP URL from debugging environment variables

### DIFF
--- a/src/mcp_browser_use/browser/browser_manager.py
+++ b/src/mcp_browser_use/browser/browser_manager.py
@@ -127,10 +127,7 @@ class BrowserEnvironmentConfig:
             )
 
         cdp_url = os.getenv("BROWSER_USE_CDP_URL") or None
-        if not cdp_url and (
-            persistence.debugging_host is not None
-            or persistence.debugging_port is not None
-        ):
+        if not cdp_url and (persistence.debugging_host or persistence.debugging_port):
             host = persistence.debugging_host or "127.0.0.1"
             port = persistence.debugging_port or 9222
             cdp_url = f"http://{host}:{port}"

--- a/src/mcp_browser_use/browser/browser_manager.py
+++ b/src/mcp_browser_use/browser/browser_manager.py
@@ -127,6 +127,13 @@ class BrowserEnvironmentConfig:
             )
 
         cdp_url = os.getenv("BROWSER_USE_CDP_URL") or None
+        if not cdp_url and (
+            persistence.debugging_host is not None
+            or persistence.debugging_port is not None
+        ):
+            host = persistence.debugging_host or "127.0.0.1"
+            port = persistence.debugging_port or 9222
+            cdp_url = f"http://{host}:{port}"
 
         user_data_dir = None
         if persistence.persistent_session:

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -1,0 +1,55 @@
+"""Tests for browser manager environment configuration helpers."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+browser_manager = importlib.import_module(
+    "mcp_browser_use.browser.browser_manager"
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_browser_env(monkeypatch):
+    """Ensure browser-related environment variables do not leak between tests."""
+
+    for key in (
+        "BROWSER_USE_CDP_URL",
+        "CHROME_DEBUGGING_HOST",
+        "CHROME_DEBUGGING_PORT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_from_env_derives_cdp_url_from_debugging(monkeypatch):
+    """When only debugging env vars are set, derive a CDP URL automatically."""
+
+    monkeypatch.setenv("CHROME_DEBUGGING_HOST", "debug.example")
+    monkeypatch.setenv("CHROME_DEBUGGING_PORT", "1337")
+
+    config = browser_manager.BrowserEnvironmentConfig.from_env()
+
+    assert config.cdp_url == "http://debug.example:1337"
+
+
+def test_create_browser_session_preserves_computed_cdp_url(monkeypatch):
+    """Computed CDP URL is passed to BrowserSession when overrides omit it."""
+
+    monkeypatch.setenv("CHROME_DEBUGGING_HOST", "localhost")
+    monkeypatch.setenv("CHROME_DEBUGGING_PORT", "9000")
+
+    captured_kwargs: dict[str, object] = {}
+
+    class DummyBrowserSession:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(browser_manager, "BrowserSession", DummyBrowserSession)
+
+    session = browser_manager.create_browser_session()
+
+    assert isinstance(session, DummyBrowserSession)
+    assert captured_kwargs["cdp_url"] == "http://localhost:9000"


### PR DESCRIPTION
## Summary
- derive a default CDP URL from CHROME_DEBUGGING_HOST/PORT when the explicit variable is unset
- ensure browser session creation keeps the derived CDP URL unless overridden
- add regression tests covering the derived CDP URL behaviour

## Testing
- pytest tests/test_browser_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d71b2133f08324b4bc0a47235916a9