### PR TITLE
Harden browser request boundaries before resource allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This repository provides a production-ready wrapper around the `browser-use` automation engine. It exposes a single MCP tool (`run_browser_agent`) that orchestrates a browser session, executes the `browser-use` agent, and returns the final result back to the client. The refactored layout focuses on keeping configuration in one place, improving testability, and keeping `browser-use` upgrades isolated from MCP specific code.
+This repository provides a beta MCP wrapper around the `browser-use` automation engine. It exposes a single MCP tool (`run_browser_agent`) that orchestrates a browser session, executes the `browser-use` agent, and returns the final result to the client. The layout keeps configuration in one place, makes security boundaries testable, and isolates upstream `browser-use` migrations from the MCP interface.
 
 ### Key Capabilities
 
@@ -25,7 +25,7 @@ This repository provides a production-ready wrapper around the `browser-use` aut
 ├── documentation/
 │   ├── CONFIGURATION.md      # Detailed configuration reference
 │   └── SECURITY.md           # Security considerations for running the server
-├── .env.example            # Example environment variables for local development
+├── sample.env.env           # Example environment variables for local development
 ├── src/mcp_browser_use/
 │   ├── agent/                # Custom agent, prompts, message history, and views
 │   ├── browser/              # Browser session factory and persistence helpers
@@ -53,7 +53,7 @@ cd mcp-browser-use
 uv sync
 ```
 
-Copy `sample.env` to `.env` (or export the variables in another way) and update the values for the providers you plan to use.
+Copy `sample.env.env` to `.env` (or export the variables another way) and update only the providers you plan to use. Never commit the populated `.env` file.
 
 ### Launching the server
 
@@ -103,14 +103,24 @@ Use `.env` + [`python-dotenv`](https://pypi.org/project/python-dotenv/) or your 
 ## Running Tests
 
 ```bash
-uv run pytest
+uv run python -m pytest -q
 ```
 
-The tests cover the custom agent behaviour, browser session factory, and other utility helpers.
+The tests cover custom-agent behavior, browser configuration, MCP input limits, secret redaction,
+and utility helpers. A dependency update is not merge-ready merely because imports or unit tests
+pass; the resolved environment must also pass its dependency and security checks.
 
 ## Security
 
 Controlling a full browser instance remotely can grant broad access to the host machine. Review [documentation/SECURITY.md](documentation/SECURITY.md) before exposing the server to untrusted environments.
+
+The MCP tool trims and bounds task/context input before allocating a model or browser session.
+Runtime step limits are constrained, proxy settings are omitted from debug logs, and CDP endpoint
+values are redacted because they may contain credentials.
+
+The Python 3.14/browser-use dependency migration remains held in
+[#45](https://github.com/JovaniPink/mcp-browser-use/issues/45) until upstream permits patched
+transitive versions. Do not force incompatible overrides or suppress the audit findings.
 
 ## Contributing
 

--- a/documentation/CONFIGURATION.md
+++ b/documentation/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 This guide describes every configuration option recognised by the MCP Browser Use server. All settings can be supplied as environment variables (e.g. via a `.env` file loaded with [`python-dotenv`](https://pypi.org/project/python-dotenv/)) or injected by your MCP client.
 
-The sample file at [`sample.env.example`](../sample.env.example) contains a ready-to-copy template with placeholders for secrets.
+The sample file at [`sample.env.env`](../sample.env.env) contains a ready-to-copy template with placeholders for secrets.
 
 ## How configuration is loaded
 
@@ -12,6 +12,13 @@ The sample file at [`sample.env.example`](../sample.env.example) contains a read
 
 Unless otherwise noted, boolean flags treat any of `1`, `true`, `yes`, `on` (case insensitive) as **true**. Any other value is considered **false**.
 
+## MCP Tool Input Contract
+
+`run_browser_agent` trims its `task` and optional `add_infos` values before use. The task must be
+non-empty, and each value is limited to 20,000 characters. Validation happens before model or
+browser-session allocation so malformed or oversized requests do not consume provider or browser
+resources.
+
 ## Core Agent Options
 
 | Variable | Default | Description |
@@ -19,8 +26,8 @@ Unless otherwise noted, boolean flags treat any of `1`, `true`, `yes`, `on` (cas
 | `MCP_MODEL_PROVIDER` | `anthropic` | LLM provider name passed to the LangChain factory. Supported values: `anthropic`, `openai`, `deepseek`, `gemini`, `ollama`, `azure_openai`. |
 | `MCP_MODEL_NAME` | `claude-3-5-sonnet-20241022` | Model identifier sent to the provider. Each provider supports its own model list. |
 | `MCP_TEMPERATURE` | `0.3` | Sampling temperature for the model. Parsed as float. |
-| `MCP_MAX_STEPS` | `30` | Maximum number of reasoning/action steps before aborting the run. Parsed as integer. |
-| `MCP_MAX_ACTIONS_PER_STEP` | `5` | Limits how many tool invocations the agent may issue in a single step. Parsed as integer. |
+| `MCP_MAX_STEPS` | `30` | Maximum number of reasoning/action steps before aborting the run. Valid range: 1–100; invalid or out-of-range values use the default. |
+| `MCP_MAX_ACTIONS_PER_STEP` | `5` | Limits how many tool invocations the agent may issue in a single step. Valid range: 1–20; invalid or out-of-range values use the default. |
 | `MCP_USE_VISION` | `true` | Enables vision features within the agent (element snapshots). |
 | `MCP_TOOL_CALL_IN_CONTENT` | `true` | Whether tool call payloads are expected inside the model response content. |
 
@@ -67,6 +74,7 @@ These options are parsed by [`BrowserEnvironmentConfig.from_env`](../src/mcp_bro
 
 - When `CHROME_PERSISTENT_SESSION` is true and `CHROME_USER_DATA` is not provided, the server logs a warning and the session falls back to ephemeral storage.
 - Remote debugging settings (`CHROME_DEBUGGING_HOST` / `CHROME_DEBUGGING_PORT`) are optional and ignored if invalid values are supplied. The server logs a warning and continues with defaults.
+- CDP URLs are passed to `browser-use` but redacted from debug output because user-info and query parameters may carry credentials.
 
 ## Additional Environment Variables
 

--- a/documentation/SECURITY.md
+++ b/documentation/SECURITY.md
@@ -1,241 +1,67 @@
-# Security
-
-> Below is a comprehensive security audit of your Browser-Use + MCP project using all the prior conversations and standard best practices for security. This is not an exhaustive penetration test but a systematic review of the major scripts and common pitfalls. We also provide suggestions for how to mitigate identified risks.
-
-1. Project Structure & High-Level Summary
-
-The code layout is:
-
- 1. Main server code server.py that runs an async event loop (loop = asyncio.new_event_loop()) within __main__):
-    - Runs a FastMCP (Model Context Protocol) server.
-    - Exposes a tool endpoint to run a single “browser agent.”
- 2. Custom Agent under the agent directory and Related Classes:
-    - custom_agent.py: Inherits from a base Agent and implements logic to parse LLM output, execute browser actions, handle vision, and create history GIFs.
-    - custom_massage_manager.py: Handles LLM output parsing and conversion to browser actions.
-    - custom_prompts.py: Contains system-level instructions for the LLM to produce a structured JSON output.
-    - custom_views.py: Data classes (CustomAgentStepInfo, CustomAgentBrain) are used to store the agent’s state and output schema.
- 3. Custom Browser Components under the browser directory:
-    - config.py: Holds dataclasses for configuring Chrome (persistent sessions, debugging port).
-    - custom_browser.py: Subclass of Browser that handles launching or connecting to Chrome over a debugging port. It may disable some security flags or run headless.
-    - custom_context.py: Subclass of BrowserContext that can reuse an existing context or create new ones, load cookies, start traces, etc.
- 4. Controllers & Actions:
-    - custom_controller.py: Registers custom actions (copy/paste from clipboard).
- 5. Utilities:
-    - agent_state.py: Tracks a stop_requested event (via asyncio.Event) and optional “last valid state.” Implemented as a singleton (only one agent at a time).
-    - utils.py: offers a get_llm_model function to create different LLM clients (OpenAI, Anthropic, Azure, etc.), as well as image encoding and file-tracking utilities.
-
-The project runs a single agent simultaneously, hooking an LLM to actual browser actions. Let’s go through significant security aspects.
-
-2. Identified Security Risks & Recommendations
-
-Below are the main areas of concern based on the code we’ve seen and typical usage patterns.
-
-2.1 Disabling Browser Security & Remote Debug Port
-
-Where
-
-- custom_browser.py:
-- Allows launching Chrome with flags like --disable-web-security.
-- Launches Chrome with --remote-debugging-port=9222.
-
-Risks
-
- 1. Cross-Origin Attacks: Disabling web security (--disable-web-security, --disable-features=IsolateOrigins) allows malicious pages to read cross-origin data in the same browser instance. If the agent visits untrusted websites, it could inadvertently exfiltrate data from other open tabs or sessions.
- 2. Debug Port Exposure: A remote debugging port on 9222 (if bound to 0.0.0.0 or otherwise accessible externally) gives anyone who can connect full control of the browser. If not behind a firewall, an attacker can hijack the session.
-
-Recommendations
-
- 1. Limit the usage of disable-web-security and related flags. Restrict this to internal/test scenarios or run it inside a hardened container or ephemeral environment.
- 2. Restrict Access to Port 9222:
-
-- Bind to 127.0.0.1 only (--remote-debugging-address=127.0.0.1) so external hosts cannot connect.
-- Use a firewall or security group to block external access.
-- If remote access is required, use SSH tunneling rather than publicly exposing the port.
-
- 3. If you must open untrusted pages, create separate browser instances. This means not reusing the same “user data dir” or disabling security for critical tasks.
-
-2.2 Global Singleton AgentState
-
-Where
-
-- agent_state.py implements a singleton that shares_stop_requested and last_valid_state across all agent references.
-
-Risks
-
- 1. Concurrent Agents: If you (in the future) attempt to run multiple agents, the single AgentState object might cause cross-talk or unpredictable behavior (e.g., one agent’s stop request stops another).
- 2. Potential Race Conditions: If the code evolves to multi-thread or multi-process, the concurrency might not behave as expected.
-
-Recommendations
-
- 1. Ensure Only One Agent: If that’s your design (a single agent at a time), the singleton is acceptable. Document it.
- 2. Remove Singleton for multi-agent scenarios. Each agent can have its state object.
-
-2.3 Clipboard Actions
-
-Where
-
-- custom_controller.py registers actions like “Copy text to clipboard” and “Paste from clipboard.”
-
-Risks
-
- 1. System Clipboard: Copy/paste using the OS-level clipboard (pyperclip). This can leak sensitive data if other apps or remote sessions see the same clipboard.
- 2. Overwrite: The agent can overwrite a user’s clipboard or read from it unexpectedly.
-
-Recommendations
-
- 1. Run in a Controlled Environment: It may be okay if you only do local development or a dedicated environment.
- 2. Use an In-Memory Clipboard: Instead of the actual system clipboard, implement a local memory store for copying and pasting within the agent’s session. This prevents overwriting the user’s system clipboard.
- 3. Disable or Restrict these actions if you run in multi-user or production mode.
-
-2.4 Logging Sensitive Data
-
-Where
-
-- Various scripts log LLM responses or user tasks.
-- utils.py and other files read environment variables for API keys.
-
-Risks
-
- 1. API Keys in Logs: If you ever log environment variables, they might contain secrets (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY).
- 2. Conversation Logs: LLM or browser actions might contain personal info or private data from pages the agent visits.
-
-Recommendations
-
- 1. Scrub Sensitive Info: Use partial redaction to log environment variables or user data.
- 2. Control Log Levels: Keep debug logs for local dev; avoid them in production or store them in a secure location.
- 3. Never commit or print raw API keys or user credentials.
-
-2.5 Environment Variables for API Keys
-
-Where
-
-- utils.py reads OPENAI_API_KEY, ANTHROPIC_API_KEY, AZURE_OPENAI_API_KEY, etc.
-
-Risks
-
- 1. Credentials Leak: Others might read if environment variables are insecurely stored or the machine is multi-tenant.
- 2. Rotation & Auditing: It is harder to rotate if you embed them in environment variables in multiple places.
-
-Recommendations
-
- 1. Use a Secret Manager: For production, store keys in Vault, AWS Secrets Manager, or a similar service, injecting them at runtime with minimal exposure.
- 2. Lock Down or Mask your environment variables in logs.
-
-2.6 Handling of Cookies & Persisted Sessions
-
-Where
-
-- custom_context.py loads cookies from a file and reuses them if cookies_file is set.
-
-Risks
-
- 1. Cookie Theft: Cookies containing session tokens can be used to impersonate or access accounts.
- 2. Insecure Storage: If cookies_file is not locked down or is in a publicly accessible directory, attackers could read it.
-
-Recommendations
-
- 1. Encrypt or Secure the cookie file if it’s sensitive.
- 2. Use ephemeral sessions if you don’t need persistence (this mitigates the risk of session hijacking).
- 3. Handle JSON Errors gracefully. The code might crash if the cookie file is corrupted or maliciously edited. Currently, you catch some exceptions, but be sure they are robust.
-
-2.7 LLM Output Execution
-
-Where
-
-- custom_agent.py uses the LLM output to determine subsequent actions in the browser. This is effectively arbitrary remote code controlling the browser if the LLM’s output is invalid.
-
-Risks
-
- 1. Prompt Injection or Malicious LLM Output: If an attacker can manipulate the prompt or the LLM’s instructions, they might cause harmful browsing actions (e.g., navigating to malicious pages, downloading malicious content, or exfiltrating data).
- 2. Excessive Trust: The agent automatically performs actions the LLM says. If the LLM is compromised or intentionally producing malicious JSON, your system might become an attack vector.
-
-Recommendations
-
- 1. Policy Layer: Before executing each action, you can add checks to ensure it’s within a set of “allowed” domains or “allowed action types.”
- 2. Safe Browsing: You could block navigation to known malicious or undesired domains.
- 3. Sandboxes: Run the browser in a locked-down Docker container or VM so the environment is contained even if the LLM instructs to visit a malicious link.
-
-2.8 Untrusted Web Content & Vision
-
-Where
-
-- The agent uses optional “vision-based element detection” or page screenshots.
-
-Risks
-
- 1. Malicious Images: If the agent processes images from untrusted sources, ensure it’s safe from typical image library exploits (PIL is relatively safe, but keep it updated).
- 2. Screenshot capturing: If you store or send screenshots, you risk inadvertently capturing personal data or content.
-
-Recommendations
-
- 1. Use the Latest Libraries: Keep PIL (pillow) updated to avoid known vulnerabilities in image parsing.
- 2. Handle Storage: If you store screenshots, do so in secure, short-lived storage with restricted access.
-
- 3. Summary of Key Security Practices
-
-Based on the potential issues above, here’s a short checklist to ensure your system remains secure:
-
- 1. Networking & Ports:
-
-- Bind remote debugging to 127.0.0.1 only.
-- Use firewalls or SSH tunnels if remote access is necessary.
-
- 2. Sandboxing:
-
-- Use Docker or a VM for your automation environment.
-- Avoid --disable-web-security in production, or keep it in an isolated environment if you must use it.
-
- 3. Logging & Secrets:
-
-- Never log API keys or raw environment variables.
-- Redact sensitive info in logs.
-- Use a secret manager to store credentials.
-
- 4. Clipboard & Persistence:
-
-- Limit usage of system clipboard actions or implement an in-memory approach.
-- If session data/cookies are reused, ensure the file and directory permissions are locked down.
-
- 5. LLM Output Validation:
-
-- Consider a “policy layer” that checks which actions are allowed before executing them.
-- Consider domain safelisting or an interactive approval step in critical scenarios.
-
- 6. Error Handling:
- •  - Gracefully handle invalid JSON, cookies, or environment variables.
-
-- Decide if you want to continue or fail fast with an error message.
-
- 7. Document your single-agent approach:
-
-- The singleton approach is fine if you never plan multiple concurrent agents.
-- Otherwise, remove it or ensure concurrency safety.
-
- 4. Verifying Project Structure
-
-From a structural standpoint:
-
- 1. Modular & Readable: Your project is decently modular: custom_agent, custom_browser, custom_context, custom_controller, custom_prompts, etc.
- 2. Dependencies: You rely on Playwright. async_api, pyperclip, requests, and custom browser_use and langchain _* modules. Ensure they are pinned to known-safe versions (e.g., in a requirements.txt) and kept updated.
- 3. Single vs. Multi Agent: In your README or main docs, clarify that you run only one agent at a time or concurrency is in scope.
- 4. Deployment: If you distribute or deploy this server, outline the usage of environment variables, the required ports, and the recommended containerization approach.
-
- 5. Conclusion
-
-Your codebase is well-organized and functionally robust. The main security concerns revolve around:
-
-- Remote Debugging & Disabling Security** in Chrome.
-- Clipboard & Cookie usage.
-- LLM output leading to potentially dangerous actions if not validated.
-- Logging & environment variables containing sensitive data.
-
-You can mitigate most of these risks by containerizing or VM-isolating your environment, restricting your debugging port to localhost, carefully handling credentials and logs, and implementing a minimal policy layer for LLM-driven actions.
-
-The project is in good shape, but you should document these security measures and carefully configure them, especially in environments other than internal development.
-
-Next Steps:
-
-- Implement or strengthen the recommended mitigation steps above.
-- Periodically review dependencies for security patches.
-- If this is a production-grade service, consider formal penetration testing or a threat model exercise to identify additional risks.
-- Keep documentation clear about the single-agent design and environment variables, and recommend using a container or ephemeral environment to prevent lateral movement or data exfiltration.
+# Security Model
+
+This server gives an LLM control of a real browser. Treat every task, page, download, screenshot,
+and browser profile as untrusted input. This document describes implemented safeguards and the
+operator responsibilities that remain outside the repository.
+
+## Implemented Boundaries
+
+- `run_browser_agent` trims and validates tool input before allocating a model or browser session.
+- Tasks and optional context are each limited to 20,000 characters.
+- `MCP_MAX_STEPS` is limited to 1–100 and `MCP_MAX_ACTIONS_PER_STEP` to 1–20; invalid values use
+  documented defaults.
+- Every tool call creates a browser session and attempts graceful cleanup, then forced cleanup when
+  supported.
+- Browser web security stays enabled unless `BROWSER_USE_DISABLE_SECURITY=true` is explicitly set.
+- Proxy configuration is omitted from debug logs.
+- CDP endpoints are redacted from debug logs because URLs may contain usernames, passwords, or
+  access tokens.
+- `BROWSER_USE_ALLOWED_DOMAINS` can restrict navigation to an operator-defined allowlist.
+
+These controls reduce accidental resource consumption and credential disclosure. They do not make
+untrusted browser automation safe by themselves.
+
+## Operator Responsibilities
+
+1. Run untrusted tasks in an isolated container or virtual machine.
+2. Use ephemeral browser profiles unless a task explicitly requires persistence. A persisted
+   profile may contain cookies, account sessions, browsing history, and saved form data.
+3. Keep provider credentials in an MCP client secret store or dedicated secret manager. Never put
+   real credentials in `sample.env.env`, source control, screenshots, issue comments, or logs.
+4. Bind Chrome DevTools Protocol endpoints to localhost or place them behind an authenticated
+   tunnel. An exposed CDP endpoint grants browser control.
+5. Keep browser security enabled. If a test requires disabled web security, isolate that browser
+   from authenticated sessions and other workloads.
+6. Restrict allowed domains for bounded workflows and review any expansion deliberately.
+7. Treat clipboard access and downloads as host-side effects. Use a dedicated runtime when a task
+   may encounter hostile content.
+8. Rotate any credential that appears in a task, URL, browser profile, log, or artifact.
+
+## Concurrency Boundary
+
+The current `AgentState` is a process-wide singleton. Operate this server as a single active agent
+per process. Multi-tenant or concurrent execution requires replacing that singleton with
+request-scoped state and proving session isolation first.
+
+## Dependency Boundary
+
+The Python 3.14/browser-use upgrade is intentionally held by
+[#45](https://github.com/JovaniPink/mcp-browser-use/issues/45). Upstream currently hard-pins
+transitive packages with published advisories. Do not suppress those advisories or force versions
+that fail the package metadata contract. Unit tests, imports, and a successful container build are
+not substitutes for a clean resolved dependency audit.
+
+## Release Checklist
+
+- run the complete test suite on every supported Python version
+- verify the installed environment has no dependency conflicts
+- audit the exact resolved production dependency set
+- build and smoke-test the runtime container when Docker files or dependencies change
+- confirm task/context limits and CDP redaction tests remain present
+- keep the README and configuration reference aligned with actual defaults and limits
+
+## Reporting
+
+Open a private security report through GitHub when disclosure would expose credentials or a usable
+exploit. For non-sensitive hardening requests, open a normal issue with the affected boundary,
+reproduction steps, and the exact version or commit tested.

--- a/src/mcp_browser_use/browser/browser_manager.py
+++ b/src/mcp_browser_use/browser/browser_manager.py
@@ -176,6 +176,10 @@ def create_browser_session(
 
     logger.debug(
         "Creating BrowserSession with kwargs: %s",
-        {k: v for k, v in kwargs.items() if k != "proxy"},
+        {
+            key: "<redacted>" if key == "cdp_url" else value
+            for key, value in kwargs.items()
+            if key != "proxy"
+        },
     )
     return BrowserSession(**kwargs)

--- a/src/mcp_browser_use/server.py
+++ b/src/mcp_browser_use/server.py
@@ -25,6 +25,47 @@ logger = logging.getLogger(__name__)
 
 app = FastMCP("mcp_browser_use")
 
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_MAX_TASK_CHARS = 20_000
+_MAX_CONTEXT_CHARS = 20_000
+
+
+def _validated_tool_input(task: str, add_infos: str) -> tuple[str, str]:
+    """Normalize and bound untrusted MCP tool input before allocating resources."""
+
+    task = task.strip()
+    add_infos = add_infos.strip()
+
+    if not task:
+        raise ValueError("task must not be empty")
+    if len(task) > _MAX_TASK_CHARS:
+        raise ValueError(f"task must not exceed {_MAX_TASK_CHARS} characters")
+    if len(add_infos) > _MAX_CONTEXT_CHARS:
+        raise ValueError(f"add_infos must not exceed {_MAX_CONTEXT_CHARS} characters")
+
+    return task, add_infos
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    """Read an integer setting and clamp invalid or unsafe values to its default."""
+
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        logger.warning("Invalid integer for %s, using default=%s", name, default)
+        return default
+
+    if not minimum <= value <= maximum:
+        logger.warning(
+            "%s must be between %s and %s, using default=%s",
+            name,
+            minimum,
+            maximum,
+            default,
+        )
+        return default
+    return value
+
 
 @app.tool()
 async def run_browser_agent(task: str, add_infos: str = "") -> str:
@@ -35,6 +76,8 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
     :param add_infos: Additional information or context for the agent.
     :return: The final result string from the agent run.
     """
+
+    task, add_infos = _validated_tool_input(task, add_infos)
 
     browser_session: Optional[Browser] = None
     agent_state = AgentState()
@@ -56,21 +99,15 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
                 logger.warning(f"Invalid float for {env_var}, using default={default}")
                 return default
 
-        def safe_int(env_var: str, default: int) -> int:
-            """Safely parse an int from an environment variable."""
-            try:
-                return int(os.getenv(env_var, str(default)))
-            except ValueError:
-                logger.warning(f"Invalid int for {env_var}, using default={default}")
-                return default
-
         # Get environment variables with defaults
         temperature = safe_float("MCP_TEMPERATURE", 0.3)
-        max_steps = safe_int("MCP_MAX_STEPS", 30)
-        use_vision = os.getenv("MCP_USE_VISION", "true").lower() == "true"
-        max_actions_per_step = safe_int("MCP_MAX_ACTIONS_PER_STEP", 5)
+        max_steps = _env_int("MCP_MAX_STEPS", 30, minimum=1, maximum=100)
+        use_vision = os.getenv("MCP_USE_VISION", "true").lower() in _TRUE_VALUES
+        max_actions_per_step = _env_int(
+            "MCP_MAX_ACTIONS_PER_STEP", 5, minimum=1, maximum=20
+        )
         tool_call_in_content = (
-            os.getenv("MCP_TOOL_CALL_IN_CONTENT", "true").lower() == "true"
+            os.getenv("MCP_TOOL_CALL_IN_CONTENT", "true").lower() in _TRUE_VALUES
         )
 
         # Prepare LLM

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 
 import pytest
 
@@ -53,3 +54,26 @@ def test_create_browser_session_preserves_computed_cdp_url(monkeypatch):
 
     assert isinstance(session, DummyBrowserSession)
     assert captured_kwargs["cdp_url"] == "http://localhost:9000"
+
+
+def test_create_browser_session_redacts_cdp_url_from_debug_log(monkeypatch, caplog):
+    """Credential-bearing CDP URLs are passed through but never logged."""
+
+    cdp_url = "wss://user:secret@browser.example/devtools?token=sensitive"
+    monkeypatch.setenv("BROWSER_USE_CDP_URL", cdp_url)
+
+    captured_kwargs: dict[str, object] = {}
+
+    class DummyBrowserSession:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(browser_manager, "BrowserSession", DummyBrowserSession)
+
+    with caplog.at_level(logging.DEBUG, logger=browser_manager.__name__):
+        browser_manager.create_browser_session()
+
+    assert captured_kwargs["cdp_url"] == cdp_url
+    assert "secret" not in caplog.text
+    assert "sensitive" not in caplog.text
+    assert "'cdp_url': '<redacted>'" in caplog.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,63 @@
+"""Security-boundary tests for the MCP server entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcp_browser_use import server
+
+
+def test_tool_input_is_trimmed():
+    assert server._validated_tool_input("  Open example.com  ", "  context  ") == (
+        "Open example.com",
+        "context",
+    )
+
+
+def test_empty_task_is_rejected():
+    with pytest.raises(ValueError, match="must not be empty"):
+        server._validated_tool_input("  ", "")
+
+
+@pytest.mark.parametrize(
+    ("task", "add_infos", "field"),
+    (
+        ("x" * (server._MAX_TASK_CHARS + 1), "", "task"),
+        ("Open example.com", "x" * (server._MAX_CONTEXT_CHARS + 1), "add_infos"),
+    ),
+)
+def test_tool_input_limits_are_enforced(task, add_infos, field):
+    with pytest.raises(ValueError, match=rf"{field} must not exceed"):
+        server._validated_tool_input(task, add_infos)
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "default", "minimum", "maximum"),
+    (
+        ("MCP_MAX_STEPS", "0", 30, 1, 100),
+        ("MCP_MAX_STEPS", "101", 30, 1, 100),
+        ("MCP_MAX_ACTIONS_PER_STEP", "0", 5, 1, 20),
+        ("MCP_MAX_ACTIONS_PER_STEP", "21", 5, 1, 20),
+        ("MCP_MAX_STEPS", "not-an-integer", 30, 1, 100),
+    ),
+)
+def test_runtime_limits_reject_invalid_or_unsafe_values(
+    monkeypatch, name, value, default, minimum, maximum
+):
+    monkeypatch.setenv(name, value)
+    assert (
+        server._env_int(name, default, minimum=minimum, maximum=maximum) == default
+    )
+
+
+def test_invalid_task_is_rejected_before_resource_allocation(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("invalid task allocated a model or browser session")
+
+    monkeypatch.setattr(server.utils, "get_llm_model", fail_if_called)
+    monkeypatch.setattr(server, "create_browser_session", fail_if_called)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        asyncio.run(server.run_browser_agent("  "))


### PR DESCRIPTION
## Summary

- trim and validate MCP task/context input before creating model or browser resources
- cap task and context values at 20,000 characters
- constrain runtime step/action settings to documented safe ranges
- redact credential-bearing CDP URLs from debug logs
- replace the stale generic security audit with a current threat model and release boundary
- align the README and configuration guide with the real sample file and beta status

## Why

The server accepted empty or unbounded requests and parsed unrestricted step/action counts before a browser run. Its debug logging also exposed the complete CDP URL, which may contain credentials in user-info or query parameters. The existing security document described historical files and recommendations rather than the controls the current repository actually implements.

## Impact

Malformed and oversized requests fail before provider or browser allocation. Operators get explicit single-agent, isolation, credential, dependency, and release boundaries. Valid existing requests remain compatible; whitespace is normalized and documented boolean true values are accepted.

## Validation

Validated commit `bb06744` in `python:3.13-slim-bookworm`:

- editable project install completed
- `python -m pip check`: no broken requirements
- focused changed-area tests: 13 passed
- `python -m compileall -q src tests`: passed
- `git diff --check`: passed
- full suite: 40 passed, 1 pre-existing stale-test failure

The full-suite failure is `tests/test_logging_configuration.py` importing removed module `mcp_browser_use.agent.custom_message_manager`. This PR does not delete or rewrite that unrelated historical test.

## Non-scope and release boundary

- Does not include the broad historical donor migration.
- Does not change browser-use or Python versions.
- Does not override or suppress vulnerable transitive dependencies.
- PR #44 remains held by issue #45 until upstream dependency metadata permits patched versions and the exact resolved environment passes audit.
- This PR should remain draft until hosted checks on this exact head are reviewed.
